### PR TITLE
use indirect reference for wire interface and forward declare interface

### DIFF
--- a/src/ClosedCube_OPT3001.cpp
+++ b/src/ClosedCube_OPT3001.cpp
@@ -27,18 +27,22 @@ OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
 THE SOFTWARE.
 
 */
-#include <Wire.h>
-
 #include "ClosedCube_OPT3001.h"
 
-ClosedCube_OPT3001::ClosedCube_OPT3001()
+/*!
+ * @brief  OPT3001 constructor using i2c
+ * @param  *theWire
+ *         optional wire
+ */
+ClosedCube_OPT3001::ClosedCube_OPT3001(TwoWire *theWire)
 {
+	_wire = theWire;
 }
 
 OPT3001_ErrorCode ClosedCube_OPT3001::begin(uint8_t address) {
 	OPT3001_ErrorCode error = NO_ERROR;
 	_address = address;
-	Wire.begin();
+	_wire->begin();
 
 	return NO_ERROR;
 }
@@ -68,11 +72,11 @@ OPT3001_Config ClosedCube_OPT3001::readConfig() {
 }
 
 OPT3001_ErrorCode ClosedCube_OPT3001::writeConfig(OPT3001_Config config) {
-	Wire.beginTransmission(_address);
-	Wire.write(CONFIG);
-	Wire.write(config.rawData >> 8);
-	Wire.write(config.rawData & 0x00FF);
-	return (OPT3001_ErrorCode)(-10 * Wire.endTransmission());
+	_wire->beginTransmission(_address);
+	_wire->write(CONFIG);
+	_wire->write(config.rawData >> 8);
+	_wire->write(config.rawData & 0x00FF);
+	return (OPT3001_ErrorCode)(-10 * _wire->endTransmission());
 }
 
 OPT3001 ClosedCube_OPT3001::readResult() {
@@ -113,19 +117,19 @@ OPT3001 ClosedCube_OPT3001::readRegister(OPT3001_Commands command) {
 
 OPT3001_ErrorCode ClosedCube_OPT3001::writeData(OPT3001_Commands command)
 {
-	Wire.beginTransmission(_address);
-	Wire.write(command);
-	return (OPT3001_ErrorCode)(-10 * Wire.endTransmission(true));
+	_wire->beginTransmission(_address);
+	_wire->write(command);
+	return (OPT3001_ErrorCode)(-10 * _wire->endTransmission(true));
 }
 
 OPT3001_ErrorCode ClosedCube_OPT3001::readData(uint16_t* data)
 {
 	uint8_t	buf[2];
 
-	Wire.requestFrom(_address, (uint8_t)2);
+	_wire->requestFrom(_address, (uint8_t)2);
 
 	int counter = 0;
-	while (Wire.available() < 2)
+	while (_wire->available() < 2)
 	{
 		counter++;
 		delay(10);
@@ -133,7 +137,7 @@ OPT3001_ErrorCode ClosedCube_OPT3001::readData(uint16_t* data)
 			return TIMEOUT_ERROR;
 	}
 
-	Wire.readBytes(buf, 2);
+	_wire->readBytes(buf, 2);
 	*data = (buf[0] << 8) | buf[1];
 
 	return NO_ERROR;

--- a/src/ClosedCube_OPT3001.h
+++ b/src/ClosedCube_OPT3001.h
@@ -32,6 +32,11 @@ THE SOFTWARE.
 #define CLOSEDCUBE_OPT3001
 
 #include <Arduino.h>
+#include <Wire.h>
+
+//  Forward declarations of Wire for board/variant combinations that don't have a default 'Wire'
+extern TwoWire Wire;
+
 
 typedef enum {
 	RESULT		= 0x00,
@@ -89,7 +94,7 @@ struct OPT3001 {
 
 class ClosedCube_OPT3001 {
 public:
-	ClosedCube_OPT3001();
+	ClosedCube_OPT3001(TwoWire *theWire = &Wire);
 
 	OPT3001_ErrorCode begin(uint8_t address);
 
@@ -102,6 +107,8 @@ public:
 	
 	OPT3001_Config readConfig();
 	OPT3001_ErrorCode writeConfig(OPT3001_Config config);
+
+    TwoWire *_wire; /**< Wire object */
 
 private:
 	uint8_t _address;


### PR DESCRIPTION
The OPT3001 library uses a direct reference to the Wire interface and therefore does not allow the user to use a different Wire interface (such as Wire1, Wire2, etc).

This PR changes the direct reference and uses an indirect reference. The user can specify the required wire interface in the constructor when creating the object. The changes here are modelled from the Adafruit BMP280 library.

A forward declaration is also provided for the case where WIRE_INTERFACES_COUNT == 0.